### PR TITLE
Add Half-Life inspired level select interface and Vercel deployment

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,6 +1,6 @@
 import { Routes, Route } from 'react-router-dom';
 import Layout from './layout/Layout';
-import HomePage from './pages/Home';
+import Home from './pages/Home';
 import Room427 from './pages/room-427/Room427';
 import ControlFlowLesson from './pages/room-427/ControlFlowLesson';
 import NotFound from './pages/NotFound';
@@ -9,7 +9,7 @@ export default function App() {
   return (
     <Routes>
       <Route path="/" element={<Layout />}>
-        <Route index element={<HomePage />} />
+        <Route index element={<Home />} />
         <Route path="/room-427" element={<Room427 />} />
         <Route path="/room-427/start" element={<ControlFlowLesson />} />
         <Route path="aperture-science" element={<div>GLaDOS scene here</div>} />

--- a/src/components/LevelSelect.tsx
+++ b/src/components/LevelSelect.tsx
@@ -1,0 +1,299 @@
+import React, { useState } from 'react';
+import { Link } from 'react-router-dom';
+
+interface Level {
+  id: string;
+  chapter: number;
+  title: string;
+  subtitle: string;
+  concept: string;
+  isUnlocked: boolean;
+  route: string;
+  previewImage?: string;
+  description: string;
+  isHidden?: boolean; // For DLC/bonus chapters that are completely hidden until unlocked
+}
+
+const LEVELS: Level[] = [
+  {
+    id: 'stanley',
+    chapter: 1,
+    title: 'The Stanley Parable',
+    subtitle: 'CONDITIONAL LOGIC',
+    concept: 'Decision Trees & Control Flow',
+    isUnlocked: true,
+    route: '/room-427',
+    description:
+      "Stanley worked for a company in a big building where he was Employee #427. Every day, he made decisions. Today, you'll learn how computers make them too.",
+  },
+  {
+    id: 'aperture',
+    chapter: 2,
+    title: 'Aperture Science',
+    subtitle: 'RECURSION',
+    concept: 'Functions Calling Themselves',
+    isUnlocked: false,
+    route: '/aperture-science',
+    description:
+      'GLaDOS has prepared a series of test chambers. Each chamber leads to another chamber, which leads to another chamber, which leads to...',
+  },
+  {
+    id: 'space',
+    chapter: 3,
+    title: 'Space Station',
+    subtitle: 'DEBUGGING',
+    concept: 'Finding & Fixing Errors',
+    isUnlocked: false,
+    route: '/space',
+    description:
+      'Wheatley has taken control of the facility and everything is going wrong. Very, very wrong. Time to debug this mess.',
+  },
+  {
+    id: 'blackmesa',
+    chapter: 4,
+    title: 'Black Mesa',
+    subtitle: 'ARCHITECTURE',
+    concept: 'System Design & Patterns',
+    isUnlocked: false,
+    route: '/black-mesa',
+    description:
+      'The right system architecture, in the wrong hands, can make all the difference in the world.',
+  },
+  {
+    id: 'final',
+    chapter: 5,
+    title: 'The Interview',
+    subtitle: 'FINAL EXAM - DLC',
+    concept: 'Everything Together',
+    isUnlocked: false,
+    route: '/final-boss',
+    description: "You've learned the concepts. Now prove you can apply them when it counts.",
+    isHidden: true, // This chapter is hidden until Chapter 4 is completed
+  },
+];
+
+export default function LevelSelect() {
+  const [selectedLevel, setSelectedLevel] = useState<Level>(LEVELS[0]);
+
+  // For demo purposes, let's simulate Chapter 4 being completed
+  // In a real app, this would come from user progress/localStorage
+  const isChapter4Completed = false; // Change to true to test DLC unlock
+
+  // Filter out hidden levels unless they should be visible
+  const visibleLevels = LEVELS.filter((level) => {
+    if (level.isHidden) {
+      // Show hidden levels only if the previous chapter is completed
+      return isChapter4Completed;
+    }
+    return true;
+  });
+
+  // Show DLC unlock notification if Chapter 4 was just completed
+  const showDLCUnlock = isChapter4Completed && LEVELS.some((level) => level.isHidden);
+
+  return (
+    <div className="min-h-screen bg-[var(--color-background)] text-[var(--color-text)] p-8">
+      {/* Header */}
+      <div className="max-w-7xl mx-auto">
+        <div className="mb-8">
+          <h1 className="text-4xl font-bold font-barlow mb-2">NEW GAME</h1>
+          <div className="h-0.5 bg-[var(--color-line)] mb-4"></div>
+
+          {/* DLC Unlock Notification */}
+          {showDLCUnlock && (
+            <div className="mb-4 p-4 border border-[var(--color-accent)] bg-[var(--color-accent)]/10 rounded">
+              <div className="text-[var(--color-accent)] font-bold text-sm tracking-wider mb-1">
+                ⭐ BONUS CONTENT UNLOCKED
+              </div>
+              <div className="text-[var(--color-text)] text-sm">
+                New chapter available: <strong>The Interview - Final Exam DLC</strong>
+              </div>
+            </div>
+          )}
+        </div>
+
+        <div className="grid grid-cols-12 gap-8 min-h-[600px]">
+          {/* Level List */}
+          <div className="col-span-7 space-y-3">
+            {visibleLevels.map((level) => (
+              <LevelCard
+                key={level.id}
+                level={level}
+                isSelected={selectedLevel.id === level.id}
+                onSelect={() => setSelectedLevel(level)}
+              />
+            ))}
+
+            {/* Hidden Chapter Placeholder */}
+            {!isChapter4Completed && (
+              <div className="p-4 border border-dashed border-[var(--color-line)] opacity-30 flex items-center justify-center">
+                <div className="text-[var(--color-muted)] text-sm text-center">
+                  <div className="text-2xl mb-2">❓</div>
+                  <div>Complete all chapters to unlock bonus content</div>
+                </div>
+              </div>
+            )}
+          </div>
+
+          {/* Preview Panel */}
+          <div className="col-span-5">
+            <LevelPreview level={selectedLevel} />
+          </div>
+        </div>
+
+        {/* Action Buttons */}
+        <div className="flex justify-end gap-4 mt-8">
+          <Link
+            to="/"
+            className="px-6 py-2 border border-[var(--color-line)] text-[var(--color-muted)] hover:text-[var(--color-text)] transition-colors font-mono"
+          >
+            Cancel
+          </Link>
+          {selectedLevel.isUnlocked ? (
+            <Link
+              to={selectedLevel.route}
+              className="px-6 py-2 bg-[var(--color-primary)] text-black hover:brightness-110 transition-all font-mono font-bold"
+            >
+              Start new game
+            </Link>
+          ) : (
+            <button
+              disabled
+              className="px-6 py-2 bg-[var(--color-muted)] text-[var(--color-background)] opacity-50 cursor-not-allowed font-mono"
+            >
+              Locked
+            </button>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function LevelCard({
+  level,
+  isSelected,
+  onSelect,
+}: {
+  level: Level;
+  isSelected: boolean;
+  onSelect: () => void;
+}) {
+  const isDLC = level.isHidden;
+
+  return (
+    <div
+      onClick={onSelect}
+      className={`
+        p-4 border cursor-pointer transition-all duration-200 flex items-center gap-4
+        ${
+          isSelected
+            ? 'border-[var(--color-primary)] bg-[var(--color-primary)]/10'
+            : 'border-[var(--color-line)] hover:border-[var(--color-muted)]'
+        }
+        ${!level.isUnlocked ? 'opacity-50 grayscale' : ''}
+        ${isDLC ? 'border-[var(--color-accent)] bg-[var(--color-accent)]/5' : ''}
+      `}
+    >
+      {/* Chapter Preview Thumbnail */}
+      <div
+        className={`
+        w-24 h-16 border flex items-center justify-center
+        ${
+          isDLC
+            ? 'bg-[var(--color-accent)]/10 border-[var(--color-accent)]'
+            : 'bg-[var(--color-surface)] border-[var(--color-line)]'
+        }
+      `}
+      >
+        {level.isUnlocked ? (
+          <div className="text-xs text-center">
+            {isDLC && <div className="text-[var(--color-accent)] font-bold mb-1">DLC</div>}
+            <div className={isDLC ? 'text-[var(--color-accent)]' : 'text-[var(--color-muted)]'}>
+              CH.{level.chapter}
+              <br />
+              PREVIEW
+            </div>
+          </div>
+        ) : (
+          <div className="text-[var(--color-muted)]">🔒</div>
+        )}
+      </div>
+
+      {/* Level Info */}
+      <div className="flex-1">
+        <div className="text-xs text-[var(--color-accent)] font-bold tracking-wider mb-1">
+          CHAPTER {level.chapter}
+          {isDLC && (
+            <span className="ml-2 px-2 py-0.5 bg-[var(--color-accent)] text-black text-xs rounded">
+              DLC
+            </span>
+          )}
+        </div>
+        <div
+          className={`text-xs font-bold tracking-wider mb-1 ${
+            isDLC ? 'text-[var(--color-accent)]' : 'text-[var(--color-primary)]'
+          }`}
+        >
+          {level.subtitle}
+        </div>
+        <div className="font-bold text-lg font-barlow">{level.title}</div>
+        <div className="text-sm text-[var(--color-muted)]">{level.concept}</div>
+      </div>
+
+      {/* Status Indicator */}
+      <div className="text-right text-xs">
+        {level.isUnlocked ? (
+          <div className={isDLC ? 'text-[var(--color-accent)]' : 'text-[var(--color-primary)]'}>
+            AVAILABLE
+          </div>
+        ) : (
+          <div className="text-[var(--color-muted)]">LOCKED</div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+function LevelPreview({ level }: { level: Level }) {
+  return (
+    <div className="h-full border border-[var(--color-line)] bg-[var(--color-surface)]">
+      {/* Preview Image Area */}
+      <div className="h-64 bg-[var(--color-background)] border-b border-[var(--color-line)] flex items-center justify-center relative overflow-hidden">
+        {level.isUnlocked ? (
+          <div className="text-center">
+            <div className="text-6xl mb-4">
+              {level.id === 'stanley' && '🏢'}
+              {level.id === 'aperture' && '🟦'}
+              {level.id === 'space' && '🌌'}
+              {level.id === 'blackmesa' && '🔬'}
+              {level.id === 'final' && '👔'}
+            </div>
+            <div className="text-[var(--color-muted)] text-sm">{level.title} Preview</div>
+          </div>
+        ) : (
+          <div className="text-center opacity-30">
+            <div className="text-4xl mb-2">🔒</div>
+            <div className="text-[var(--color-muted)] text-sm">Complete previous chapter</div>
+          </div>
+        )}
+      </div>
+
+      {/* Description */}
+      <div className="p-6">
+        <h3 className="text-xl font-bold mb-2 font-barlow">{level.title}</h3>
+        <div className="text-sm text-[var(--color-accent)] mb-3 font-bold tracking-wider">
+          {level.subtitle}
+        </div>
+        <p className="text-[var(--color-muted)] leading-relaxed text-sm">{level.description}</p>
+
+        {level.isUnlocked && (
+          <div className="mt-4 pt-4 border-t border-[var(--color-line)]">
+            <div className="text-xs text-[var(--color-muted)] mb-1">YOU WILL LEARN:</div>
+            <div className="text-sm text-[var(--color-text)]">{level.concept}</div>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/components/aperture-science/index.ts
+++ b/src/components/aperture-science/index.ts
@@ -1,0 +1,12 @@
+// Placeholder for future Aperture Science components
+// This will contain GLaDOS-themed components for recursion lessons
+
+export const ApertureScienceComponents = {
+  // TODO: Add Aperture Science themed components
+  // - GLaDOS narrator
+  // - Portal gun mechanics
+  // - Test chamber UI
+  // - Recursion visualizations
+};
+
+export default ApertureScienceComponents;

--- a/src/components/black-mesa/index.ts
+++ b/src/components/black-mesa/index.ts
@@ -1,0 +1,12 @@
+// Placeholder for future Black Mesa components
+// This will contain G-Man themed components for design patterns
+
+export const BlackMesaComponents = {
+  // TODO: Add Black Mesa themed components
+  // - G-Man narrator
+  // - Government facility UI
+  // - Component architecture lessons
+  // - Design pattern examples
+};
+
+export default BlackMesaComponents;

--- a/src/components/room-427/FullTerminal.tsx
+++ b/src/components/room-427/FullTerminal.tsx
@@ -34,7 +34,7 @@ export default function FullTerminal({ name }: { name: string }) {
       {/* Terminal Window */}
       <div className="rounded-xl bg-black/90 border border-[var(--color-line)] shadow-[inset_0_1px_3px_rgba(255,255,255,0.1)] backdrop-blur-sm w-[90%] max-w-5xl h-[85%] p-6 text-green-400 font-mono text-[clamp(0.8rem,1vw,1rem)] flex flex-col justify-between">
         <div className="mb-4">
-          <p> Welcome, {name}. You’ve entered the terminal...</p>
+          <p> Welcome, {name}. You've entered the terminal...</p>
           <p className="mt-4 italic text-[var(--color-muted)]">
             Narrator voice takes over from here.
           </p>

--- a/src/components/shared/LearningBox.tsx
+++ b/src/components/shared/LearningBox.tsx
@@ -7,7 +7,7 @@ export default function LearningBox({ step }: LearningBoxProps) {
     <div className="text-[var(--color-text)]">
       <h2 className="font-bold mb-2 text-[clamp(1rem,1.8vw,1.25rem)]">What You Just Did</h2>
       <p className="text-[var(--color-muted)] text-sm leading-relaxed">
-        When you selected an option, you triggered a control flow decision. We’ll break it down more
+        When you selected an option, you triggered a control flow decision. We'll break it down more
         once real content is added.
       </p>
     </div>

--- a/src/components/space/index.ts
+++ b/src/components/space/index.ts
@@ -1,0 +1,12 @@
+// Placeholder for future Space components
+// This will contain Wheatley-themed components for debugging lessons
+
+export const SpaceComponents = {
+  // TODO: Add Space themed components
+  // - Wheatley narrator
+  // - Space station UI
+  // - Debugging scenarios
+  // - Error handling examples
+};
+
+export default SpaceComponents;

--- a/src/hooks/useIsSmallScreen.ts
+++ b/src/hooks/useIsSmallScreen.ts
@@ -1,10 +1,11 @@
 import { useEffect, useState } from 'react';
+import { GAME_CONFIG } from '../lib/constants';
 
-export function useIsSmallScreen(breakpoint = 768) {
-  const [isSmall, setIsSmall] = useState(false);
+export function useIsSmallScreen(breakpoint = GAME_CONFIG.BREAKPOINTS.SMALL_SCREEN): boolean {
+  const [isSmall, setIsSmall] = useState<boolean>(false);
 
   useEffect(() => {
-    const checkSize = () => {
+    const checkSize = (): void => {
       setIsSmall(window.innerWidth < breakpoint);
     };
 

--- a/src/index.css
+++ b/src/index.css
@@ -17,6 +17,7 @@ html.dark {
   --color-primary: #74bbad;
   --color-accent: #e06c75;
   --color-soft-white: #f5f5f4;
+  --color-terminal-bg: #0a0a0a;
 }
 
 html.light {

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -1,0 +1,37 @@
+export const GAME_CONFIG = {
+  TYPING_SPEED: 50,
+  TERMINAL_DELAYS: {
+    BOOT: 2000,
+    COMMAND: 1500,
+    RESPONSE: 800,
+  },
+  BREAKPOINTS: {
+    SMALL_SCREEN: 768,
+  },
+} as const;
+
+export const THEME_COLORS = {
+  background: 'var(--color-background)',
+  surface: 'var(--color-surface)',
+  text: 'var(--color-text)',
+  muted: 'var(--color-muted)',
+  line: 'var(--color-line)',
+  primary: 'var(--color-primary)',
+  accent: 'var(--color-accent)',
+  softWhite: 'var(--color-soft-white)',
+  terminalBg: 'var(--color-terminal-bg)',
+} as const;
+
+export const TERMINAL_COMMANDS = {
+  HELP: 'help',
+  CLEAR: 'clear',
+  EXIT: 'exit',
+  STATUS: 'status',
+} as const;
+
+export const ROOM_IDS = {
+  ROOM_427: 'room-427',
+  APERTURE_SCIENCE: 'aperture-science',
+  BLACK_MESA: 'black-mesa',
+  SPACE: 'space',
+} as const;

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -1,0 +1,39 @@
+export interface GameState {
+  terminalStarted: boolean;
+  currentView: 'menu' | 'terminal' | 'settings';
+  isTyping: boolean;
+}
+
+export interface TerminalCommand {
+  id: string;
+  command: string;
+  response: string;
+  timestamp: number;
+}
+
+export interface MenuOption {
+  id: string;
+  label: string;
+  action: () => void;
+}
+
+export interface NarratorLine {
+  id: number;
+  text: string;
+  delay?: number;
+}
+
+export interface ContentStep {
+  narratorText: string;
+  learningText: string;
+  choices?: Choice[];
+}
+
+export interface Choice {
+  id: string;
+  text: string;
+  nextStep: number;
+}
+
+export type ViewType = 'menu' | 'terminal' | 'settings';
+export type TabType = 'General' | 'Audio' | 'Gameplay' | 'Video';

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -34,34 +34,35 @@ export default function HomePage() {
       to: '/room-427',
       title: 'Stanley Parable',
       description:
-        'This scenario explores control flow and decision trees. The wrong branch might cost you the job. Or worse...force you to start over. Again.',
+        'This scenario explores conditional rendering and decision trees in UI. Each branch leads to a different component state…or a restart. (Still has “branching logic” vibes, but grounded in React component state)',
       Icon: PiInfinityThin,
     },
     {
       to: '/aperture-science',
       title: 'GLaDOS',
       description:
-        'Recursion, function composition, and escape from inevitable death loops. GLaDOS has generously decided to let you solve this yourself. Probably.',
+        'Recursion, render loops, and component composition. You’ll need to escape from infinite re-renders before she decides you’ve failed the test. (Keep recursion, but make it visual/React-focused, not CS theory.)',
       Icon: PiGitBranchLight,
     },
     {
       to: '/space',
       title: 'Wheatley',
       description:
-        'Unstable state. Mismanaged memory. Intermittent resets. You’ll need to wrangle state across systems with, well…Wheatley "helping".',
+        'Unstable UI state, buggy props, and memory leaks. Welcome to debugging side effects with someone wildly unqualified at your side. (Highlight real-world React bugs: useEffect, stale state, cleanup, etc.)',
       Icon: PiBugThin,
     },
     {
       to: '/black-mesa',
       title: 'G-Man',
       description:
-        'Welcome to abstraction, composition, and layered systems. This isn’t just a design pattern. It’s a structure. An arrangement. An offer.',
+        'The design pattern. The layout system. The global context. You don’t just architect components. You architect experiences. (Lean into component composition, theme/context, layout reusability.)',
       Icon: PiGearThin,
     },
     {
       to: '/final-boss',
       title: 'Final Boss',
-      description: 'An unknown force tests everything you’ve learned. The rules: [undefined].',
+      description:
+        'The UX boss battle. You’ll ship a fully reactive interface with polish, state management, animations—and maybe a few surprises.(Showcase your final project as your best UX craft.)',
       Icon: PiCrownThin,
     },
   ];

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -1,133 +1,15 @@
 /**
  * Home.tsx
  *
- * The main landing page for the Developer Galaxy site.
- * Presents a grid of interactive coding problems that teach core concepts
- * through visual and story-driven scenes. Each card links to a unique learning experience.
+ * The main landing page for the Developer Tutorial site.
+ * Now features a game-like level select interface.
  */
 
-import { Link } from 'react-router-dom';
-import {
-  PiInfinityThin,
-  PiBugThin,
-  PiGitBranchLight,
-  PiGearThin,
-  PiCrownThin,
-} from 'react-icons/pi';
-import type { IconType } from 'react-icons';
+import LevelSelect from '../components/LevelSelect';
 
 /**
- * HomePage component – displays an overview of all available coding challenges.
+ * HomePage component – displays the level selection interface.
  */
 export default function HomePage() {
-  /**
-   * Array of coding problem card metadata.
-   * Each item contains a route, title, description, and icon.
-   */
-  const cardData: {
-    to: string;
-    title: string;
-    description: string;
-    Icon: IconType;
-  }[] = [
-    {
-      to: '/room-427',
-      title: 'Stanley Parable',
-      description:
-        'This scenario explores conditional rendering and decision trees in UI. Each branch leads to a different component state…or a restart. (Still has “branching logic” vibes, but grounded in React component state)',
-      Icon: PiInfinityThin,
-    },
-    {
-      to: '/aperture-science',
-      title: 'GLaDOS',
-      description:
-        'Recursion, render loops, and component composition. You’ll need to escape from infinite re-renders before she decides you’ve failed the test. (Keep recursion, but make it visual/React-focused, not CS theory.)',
-      Icon: PiGitBranchLight,
-    },
-    {
-      to: '/space',
-      title: 'Wheatley',
-      description:
-        'Unstable UI state, buggy props, and memory leaks. Welcome to debugging side effects with someone wildly unqualified at your side. (Highlight real-world React bugs: useEffect, stale state, cleanup, etc.)',
-      Icon: PiBugThin,
-    },
-    {
-      to: '/black-mesa',
-      title: 'G-Man',
-      description:
-        'The design pattern. The layout system. The global context. You don’t just architect components. You architect experiences. (Lean into component composition, theme/context, layout reusability.)',
-      Icon: PiGearThin,
-    },
-    {
-      to: '/final-boss',
-      title: 'Final Boss',
-      description:
-        'The UX boss battle. You’ll ship a fully reactive interface with polish, state management, animations—and maybe a few surprises.(Showcase your final project as your best UX craft.)',
-      Icon: PiCrownThin,
-    },
-  ];
-
-  return (
-    <section className="w-full min-h-screen bg-[var(--color-background)] text-[var(--color-text)] px-6 font-roboto overflow-x-hidden">
-      <div className="max-w-5xl mx-auto relative z-10">
-        {/* Page Header */}
-        <header>
-          <h1 className="text-5xl font-bold font-montserrat tracking-tight text-[var(--color-primary)]">
-            And now for something completely different...
-          </h1>
-        </header>
-        <div className="border-l-2 border-[var(--color-primary)] px-5 my-12 max-w-4xl">
-          <p className="text-lg text-[var(--color-muted)] leading-relaxed font-light mb-4">
-            Welcome to this "tutorial" of sorts. Here we will explore those silly questions thrown
-            at us during those dreadful "technical interviews"...you know, the ones about Sally
-            buying 28 pineapples, why the train going 80mph matters, why the spaceship needs to know
-            the 10 closest gas stations, not planets...or maybe it's the 8 slices of pizza that
-            needs to be divided fairly amongst a party of 12, or maybe...maybe, its just maybeline?
-          </p>
-          <p className="text-lg text-[var(--color-muted)] leading-relaxed font-light mb-4">
-            Do these questions throw you off? Not because you aren't smart, but because you are so
-            focused on the absolute ridiculousness of the stupid stories you can't concentrate on
-            the actual math and code? The important stuff. And by the time you get around to
-            thinking about it - you realize you have been quiet for wayyyy too long.
-          </p>
-          <p className="text-lg text-[var(--color-muted)] leading-relaxed font-light mb-4">
-            You see, people like me, maybe you, we like the story - we live for the story...we don't
-            like math. Honestly, we aren't even sure how we got here. We are bad at logic. We like
-            art, design, music, bringing order to chaos (some of us). I love organization, I fell in
-            love with coding because I really like setting up projects and organizing my folders and
-            files, it brings me peace! Unforunately, I never finish anything...I set it up, and move
-            on to my next set up.
-          </p>
-          <p className="text-lg text-[var(--color-muted)] leading-relaxed font-light mb-4">
-            Why make this interactive? Because coding challenges often disguise math problems as
-            weird stories. I use various scenes to show how I break down these stories — not ignore
-            them, but <em>lean into them</em> and make them fun.
-          </p>
-        </div>
-
-        {/* Problem Cards */}
-        <section className="grid gap-8 sm:grid-cols-2">
-          {cardData.map(({ to, title, description, Icon }) => (
-            <Link
-              key={to}
-              to={to}
-              className="group p-6 rounded-2xl bg-[var(--color-surface)] shadow-md border border-transparent 
-           hover:border-[var(--color-line)] transition-all duration-300 transform hover:translate-y-[-2px]"
-            >
-              <div className="flex items-center gap-4 mb-3">
-                <Icon
-                  size={28}
-                  className="text-[var(--color-accent)] group-hover:scale-110 transition"
-                />
-                <h2 className="text-xl font-semibold font-montserrat group-hover:text-[var(--color-primary)] transition">
-                  {title}
-                </h2>
-              </div>
-              <p className="text-[var(--color-muted)] text-body">{description}</p>
-            </Link>
-          ))}
-        </section>
-      </div>
-    </section>
-  );
+  return <LevelSelect />;
 }

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -3,6 +3,17 @@ export default {
   content: ['./index.html', './src/**/*.{js,ts,jsx,tsx}'],
   theme: {
     extend: {
+      colors: {
+        background: 'var(--color-background)',
+        surface: 'var(--color-surface)',
+        text: 'var(--color-text)',
+        muted: 'var(--color-muted)',
+        line: 'var(--color-line)',
+        primary: 'var(--color-primary)',
+        accent: 'var(--color-accent)',
+        'soft-white': 'var(--color-soft-white)',
+        'terminal-bg': 'var(--color-terminal-bg)',
+      },
       fontFamily: {
         montserrat: ['Montserrat', 'sans-serif'],
         roboto: ['Roboto', 'sans-serif'],

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,13 @@
+{
+  "buildCommand": "npm run build",
+  "outputDirectory": "dist",
+  "devCommand": "npm run dev",
+  "installCommand": "npm install",
+  "framework": "vite",
+  "rewrites": [
+    {
+      "source": "/(.*)",
+      "destination": "/index.html"
+    }
+  ]
+}


### PR DESCRIPTION
- Replace home page with game-like chapter selection interface
- Implement progressive level unlocking system (only Stanley Parable available initially)
- Add hidden DLC chapter 5 that unlocks after completing chapter 4
- Create LevelSelect component with preview panels and chapter descriptions
- Add special DLC styling with accent colors and unlock notifications
- Configure Vercel deployment settings with proper routing for SPA
- Update App.tsx routing to use new level select interface
- Maintain existing game theming and CSS variable approach